### PR TITLE
refactor: remove buildUserCache, call getSlackUserName on-demand

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,6 +45,12 @@ The `agent-browser` npm package is installed globally by the sandbox, but `agent
 - Tighten types in `message-context.ts` now that `getAuthorName` no longer takes `ctxId`
 - Files: `apps/bot/src/slack/conversations.ts`, `apps/bot/src/slack/events/message-create/utils/message-context.ts`, `apps/bot/src/utils/triggers.ts`, `apps/bot/src/utils/context.ts`
 
+### Bug: Slack search errors mark entire task as failed + pinned items shown incorrectly
+When the bot performs a Slack search (e.g. searching for pinned messages or user-pinned items), errors from the search API bubble up and mark the whole task as a failure in the task list. The user sees the entire task as red/failed even if the core work succeeded. Additionally, pinned item detection doesn't correctly identify items the user has pinned — it may be checking the wrong field or returning all pins regardless of who pinned them.
+- Investigate: does the search error get caught and surfaced as a task failure? Wrap search calls so errors are non-fatal.
+- Investigate: pinned item filter logic — check whether `conversations.info` pin fields vs. `pins.list` API is being used, and whether user-specific pinning is filterable.
+- Files: `apps/bot/src/lib/ai/` (search tool), wherever pinned item logic lives
+
 ### Refactor: Split monorepo packages further
 Consider extracting:
 - **`@repo/observability`** — telemetry/Langfuse setup currently lives in `apps/bot/src/lib/ai/telemetry.ts`, could be a shared package if `apps/server` ever needs it

--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,14 @@ The `agent-browser` npm package is installed globally by the sandbox, but `agent
 - Add `agentmail` to the E2B sandbox template (rebuild with `bun run build:template`)
 - Or note it as a first-run install in the skill documentation
 
+### Refactor: Clean up message pipeline utilities
+`message-context.ts`, `triggers.ts`, `conversations.ts`, and `context.ts` accumulated dead code and duplicate patterns from the `users.info` caching work. Worth a pass to:
+- Remove any remaining inline `users.info` calls (should all go through `getSlackUserName`)
+- Simplify `buildUserCache` in `conversations.ts` — now just a thin wrapper
+- Audit `triggers.ts` for any leftover priming logic
+- Tighten types in `message-context.ts` now that `getAuthorName` no longer takes `ctxId`
+- Files: `apps/bot/src/slack/conversations.ts`, `apps/bot/src/slack/events/message-create/utils/message-context.ts`, `apps/bot/src/utils/triggers.ts`, `apps/bot/src/utils/context.ts`
+
 ### Refactor: Split monorepo packages further
 Consider extracting:
 - **`@repo/observability`** — telemetry/Langfuse setup currently lives in `apps/bot/src/lib/ai/telemetry.ts`, could be a shared package if `apps/server` ever needs it

--- a/apps/bot/src/lib/ai/tools/chat/get-user-info.ts
+++ b/apps/bot/src/lib/ai/tools/chat/get-user-info.ts
@@ -5,7 +5,7 @@ import { createTask, finishTask, updateTask } from '@/lib/ai/utils/task';
 import logger from '@/lib/logger';
 import type { SlackMessageContext, Stream } from '@/types';
 import { getContextId } from '@/utils/context';
-import { normalizeSlackUserId } from '@/utils/users';
+import { normalizeSlackUserId, primeSlackUser } from '@/utils/users';
 
 export const getUserInfo = ({
   context,
@@ -41,9 +41,15 @@ export const getUserInfo = ({
       try {
         const targetId = normalizeSlackUserId(userId);
 
-        const user = targetId
-          ? ((await context.client.users.info({ user: targetId })).user ?? null)
-          : null;
+        if (!targetId) {
+          await finishTask(stream, { status: 'error', taskId: task });
+          return {
+            success: false,
+            error: 'User not found. Use their Slack ID.',
+          };
+        }
+
+        const { user } = await context.client.users.info({ user: targetId });
 
         if (!user) {
           await finishTask(stream, { status: 'error', taskId: task });
@@ -52,22 +58,34 @@ export const getUserInfo = ({
             error: 'User not found. Use their Slack ID.',
           };
         }
+
+        const name =
+          user.profile?.display_name || user.real_name || user.name || targetId;
+        primeSlackUser(targetId, {
+          name,
+          displayName: user.profile?.display_name ?? null,
+          realName: user.profile?.real_name ?? null,
+          title: user.profile?.title ?? null,
+          isBot: user.is_bot ?? false,
+          tz: user.tz ?? null,
+        });
+
         await finishTask(stream, { status: 'complete', taskId: task });
         return {
           success: true,
           data: {
-            id: user.id,
-            username: user.name,
-            displayName: user.profile?.display_name,
-            realName: user.profile?.real_name,
-            statusText: user.profile?.status_text,
-            statusEmoji: user.profile?.status_emoji,
-            isBot: user.is_bot,
-            tz: user.tz,
+            id: targetId,
+            name,
+            displayName: user.profile?.display_name ?? null,
+            realName: user.profile?.real_name ?? null,
+            title: user.profile?.title ?? null,
+            isBot: user.is_bot ?? false,
+            tz: user.tz ?? null,
+            statusText: user.profile?.status_text ?? null,
+            statusEmoji: user.profile?.status_emoji ?? null,
             updated: user.updated,
-            title: user.profile?.title,
             teamId: user.team_id,
-            idResolved: targetId ?? null,
+            idResolved: targetId,
           },
         };
       } catch (error) {

--- a/apps/bot/src/lib/ai/tools/chat/reply.ts
+++ b/apps/bot/src/lib/ai/tools/chat/reply.ts
@@ -5,7 +5,7 @@ import { createTask, finishTask, updateTask } from '@/lib/ai/utils/task';
 import logger from '@/lib/logger';
 import type { SlackHistoryMessage, SlackMessageContext, Stream } from '@/types';
 import { getContextId } from '@/utils/context';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 async function resolveTargetMessage(
   ctx: SlackMessageContext,
@@ -141,7 +141,7 @@ export const reply = ({
         }
 
         const authorName = userId
-          ? await getSlackUserName(context.client, userId)
+          ? (await getSlackUser(context.client, userId)).name
           : 'unknown';
 
         logger.info(

--- a/apps/bot/src/lib/ai/tools/chat/skip.ts
+++ b/apps/bot/src/lib/ai/tools/chat/skip.ts
@@ -4,7 +4,7 @@ import { createTask, finishTask, updateTask } from '@/lib/ai/utils/task';
 import logger from '@/lib/logger';
 import type { SlackMessageContext, Stream } from '@/types';
 import { getContextId } from '@/utils/context';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 export const skip = ({
   context,
@@ -41,7 +41,7 @@ export const skip = ({
         const authorId = context.event.user;
         const content = context.event.text ?? '';
         const author = authorId
-          ? await getSlackUserName(context.client, authorId)
+          ? (await getSlackUser(context.client, authorId)).name
           : 'unknown';
         logger.info(
           { ctxId, reason, message: `${author}: ${content}` },

--- a/apps/bot/src/slack/conversations.ts
+++ b/apps/bot/src/slack/conversations.ts
@@ -3,7 +3,7 @@ import type { ModelMessage, UserContent } from 'ai';
 import logger from '@/lib/logger';
 import type { ConversationOptions, SlackConversationMessage } from '@/types';
 import { processSlackFiles } from '@/utils/images';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 async function joinChannel(
   client: ConversationOptions['client'],
@@ -115,11 +115,16 @@ async function toModelMessage(
   const textContent = cleaned.length > 0 ? cleaned : original;
 
   const authorId = message.user ?? message.bot_id ?? 'unknown';
-  const author = message.user
-    ? await getSlackUserName(client, message.user)
+  const slackUser = message.user
+    ? await getSlackUser(client, message.user)
+    : null;
+  const authorLabel = slackUser
+    ? slackUser.title
+      ? `${slackUser.name} [${slackUser.title}]`
+      : slackUser.name
     : (message.bot_id ?? 'unknown');
 
-  const formattedText = `${author} (${authorId}): ${textContent}`;
+  const formattedText = `${authorLabel} (${authorId}): ${textContent}`;
 
   if (isAssistantMessage) {
     return { role: 'assistant', content: formattedText };
@@ -156,7 +161,9 @@ export async function getConversationMessages({
       oldest,
       inclusive,
     });
-    const sortedMessages = sortForModel(filterMessages(messages, latest, inclusive));
+    const sortedMessages = sortForModel(
+      filterMessages(messages, latest, inclusive)
+    );
     const modelMessages: ModelMessage[] = [];
     for (const message of sortedMessages) {
       modelMessages.push(

--- a/apps/bot/src/slack/conversations.ts
+++ b/apps/bot/src/slack/conversations.ts
@@ -81,28 +81,6 @@ function filterMessages(
   });
 }
 
-async function buildUserCache(
-  client: ConversationOptions['client'],
-  messages: SlackConversationMessage[]
-): Promise<Map<string, string>> {
-  const userIds = new Set<string>();
-  for (const message of messages) {
-    if (message.user) {
-      userIds.add(message.user);
-    }
-  }
-
-  const userCache = new Map<string, string>();
-  await Promise.all(
-    Array.from(userIds).map(async (userId) => {
-      const name = await getSlackUserName(client, userId);
-      userCache.set(userId, name);
-    })
-  );
-
-  return userCache;
-}
-
 function sortForModel(messages: SlackConversationMessage[]) {
   return messages
     .filter(
@@ -121,12 +99,12 @@ function sortForModel(messages: SlackConversationMessage[]) {
 async function toModelMessage(
   message: SlackConversationMessage,
   options: {
+    client: ConversationOptions['client'];
     botUserId?: string;
     mentionRegex: RegExp | null;
-    userCache: Map<string, string>;
   }
 ): Promise<ModelMessage> {
-  const { botUserId, mentionRegex, userCache } = options;
+  const { client, botUserId, mentionRegex } = options;
 
   const isAssistantMessage =
     message.user === botUserId || Boolean(message.bot_id);
@@ -136,10 +114,10 @@ async function toModelMessage(
     : original.trim();
   const textContent = cleaned.length > 0 ? cleaned : original;
 
-  const author = message.user
-    ? (userCache.get(message.user) ?? message.user)
-    : (message.bot_id ?? 'unknown');
   const authorId = message.user ?? message.bot_id ?? 'unknown';
+  const author = message.user
+    ? await getSlackUserName(client, message.user)
+    : (message.bot_id ?? 'unknown');
 
   const formattedText = `${author} (${authorId}): ${textContent}`;
 
@@ -178,15 +156,14 @@ export async function getConversationMessages({
       oldest,
       inclusive,
     });
-    const filteredMessages = filterMessages(messages, latest, inclusive);
-    const userCache = await buildUserCache(client, filteredMessages);
-    const sortedMessages = sortForModel(filteredMessages);
-
-    return await Promise.all(
-      sortedMessages.map((message) =>
-        toModelMessage(message, { botUserId, mentionRegex, userCache })
-      )
-    );
+    const sortedMessages = sortForModel(filterMessages(messages, latest, inclusive));
+    const modelMessages: ModelMessage[] = [];
+    for (const message of sortedMessages) {
+      modelMessages.push(
+        await toModelMessage(message, { client, botUserId, mentionRegex })
+      );
+    }
+    return modelMessages;
   } catch (error) {
     logger.error(
       { ...toLogError(error), channel, threadTs },

--- a/apps/bot/src/slack/conversations.ts
+++ b/apps/bot/src/slack/conversations.ts
@@ -118,11 +118,14 @@ async function toModelMessage(
   const slackUser = message.user
     ? await getSlackUser(client, message.user)
     : null;
-  const authorLabel = slackUser
-    ? slackUser.title
-      ? `${slackUser.name} [${slackUser.title}]`
-      : slackUser.name
-    : (message.bot_id ?? 'unknown');
+  let authorLabel: string;
+  if (!slackUser) {
+    authorLabel = message.bot_id ?? 'unknown';
+  } else if (slackUser.title) {
+    authorLabel = `${slackUser.name} [${slackUser.title}]`;
+  } else {
+    authorLabel = slackUser.name;
+  }
 
   const formattedText = `${authorLabel} (${authorId}): ${textContent}`;
 

--- a/apps/bot/src/slack/events/message-create/utils/message-context.ts
+++ b/apps/bot/src/slack/events/message-create/utils/message-context.ts
@@ -108,5 +108,6 @@ export function getAuthorName(ctx: SlackMessageContext): Promise<string> {
   if (!userId) {
     return Promise.resolve('unknown');
   }
-  return (await getSlackUser(ctx.client, userId)).name;
+  const user = await getSlackUser(ctx.client, userId);
+  return user.name;
 }

--- a/apps/bot/src/slack/events/message-create/utils/message-context.ts
+++ b/apps/bot/src/slack/events/message-create/utils/message-context.ts
@@ -103,10 +103,10 @@ export function shouldHandleMessage(
   return Boolean(event.user) && !messageText.startsWith('##');
 }
 
-export function getAuthorName(ctx: SlackMessageContext): Promise<string> {
+export async function getAuthorName(ctx: SlackMessageContext): Promise<string> {
   const userId = ctx.event.user;
   if (!userId) {
-    return Promise.resolve('unknown');
+    return 'unknown';
   }
   const user = await getSlackUser(ctx.client, userId);
   return user.name;

--- a/apps/bot/src/slack/events/message-create/utils/message-context.ts
+++ b/apps/bot/src/slack/events/message-create/utils/message-context.ts
@@ -6,7 +6,7 @@ import type {
   SlackMessageEvent,
   SlackRawMessageEvent,
 } from '@/types';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 function isSlackFile(value: unknown): value is SlackFile {
   return Boolean(asRecord(value));
@@ -108,5 +108,5 @@ export function getAuthorName(ctx: SlackMessageContext): Promise<string> {
   if (!userId) {
     return Promise.resolve('unknown');
   }
-  return getSlackUserName(ctx.client, userId);
+  return (await getSlackUser(ctx.client, userId)).name;
 }

--- a/apps/bot/src/slack/events/message-create/utils/respond.ts
+++ b/apps/bot/src/slack/events/message-create/utils/respond.ts
@@ -16,7 +16,7 @@ import { setConversationTitle } from '@/lib/ai/utils/title';
 import type { ChatRequestHints, SlackMessageContext, Stream } from '@/types';
 import { getContextId } from '@/utils/context';
 import { processSlackFiles } from '@/utils/images';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 export async function generateResponse(
   context: SlackMessageContext,
@@ -54,7 +54,7 @@ export async function generateResponse(
     }
     const files = context.event.files;
     const authorName = userId
-      ? await getSlackUserName(context.client, userId)
+      ? (await getSlackUser(context.client, userId)).name
       : 'user';
 
     const imageContents = await processSlackFiles(files);

--- a/apps/bot/src/utils/triggers.ts
+++ b/apps/bot/src/utils/triggers.ts
@@ -3,7 +3,7 @@ import type {
   SlackMessageEvent,
   TriggerType,
 } from '@/types';
-import { getSlackUserName } from '@/utils/users';
+import { getSlackUser } from '@/utils/users';
 
 function isPlainMessage(
   event: SlackMessageEvent
@@ -31,7 +31,7 @@ export async function getTrigger(
   const content = event.text.trim();
 
   if (botId && content.includes(`<@${botId}>`)) {
-    const displayName = await getSlackUserName(client, botId);
+    const displayName = (await getSlackUser(client, botId)).name;
     return { type: 'ping', info: displayName };
   }
 

--- a/apps/bot/src/utils/users.ts
+++ b/apps/bot/src/utils/users.ts
@@ -2,14 +2,35 @@ import { toLogError } from '@repo/utils/error';
 import type { WebClient } from '@slack/web-api';
 import logger from '@/lib/logger';
 
-const cache = new Map<string, string>();
+export type SlackUser = {
+  id: string;
+  name: string;
+  displayName: string | null;
+  realName: string | null;
+  title: string | null;
+  isBot: boolean;
+  tz: string | null;
+};
 
-export async function getSlackUserName(
+const cache = new Map<string, SlackUser>();
+const inFlight = new Map<string, Promise<SlackUser>>();
+
+export async function getSlackUser(
   client: WebClient,
   userId: string
-): Promise<string> {
+): Promise<SlackUser> {
+  const fallback: SlackUser = {
+    id: userId,
+    name: userId,
+    displayName: null,
+    realName: null,
+    title: null,
+    isBot: false,
+    tz: null,
+  };
+
   if (!userId) {
-    return 'unknown';
+    return fallback;
   }
 
   const cached = cache.get(userId);
@@ -17,30 +38,62 @@ export async function getSlackUserName(
     return cached;
   }
 
-  try {
-    const info = await client.users.info({ user: userId });
-    const name =
-      info.user?.profile?.display_name ||
-      info.user?.real_name ||
-      info.user?.name ||
-      userId;
-    cache.set(userId, name);
-    return name;
-  } catch (error) {
-    logger.warn(
-      { ...toLogError(error), userId },
-      'Failed to fetch Slack user info'
-    );
-    cache.set(userId, userId);
-    return userId;
+  const existing = inFlight.get(userId);
+  if (existing) {
+    return existing;
   }
+
+  const promise = (async () => {
+    try {
+      const info = await client.users.info({ user: userId });
+      const user = info.user;
+      const result: SlackUser = {
+        id: userId,
+        name:
+          user?.profile?.display_name ||
+          user?.real_name ||
+          user?.name ||
+          userId,
+        displayName: user?.profile?.display_name ?? null,
+        realName: user?.profile?.real_name ?? null,
+        title: user?.profile?.title ?? null,
+        isBot: user?.is_bot ?? false,
+        tz: user?.tz ?? null,
+      };
+      cache.set(userId, result);
+      return result;
+    } catch (error) {
+      logger.warn(
+        { ...toLogError(error), userId },
+        'Failed to fetch Slack user info'
+      );
+      cache.set(userId, fallback);
+      return fallback;
+    } finally {
+      inFlight.delete(userId);
+    }
+  })();
+
+  inFlight.set(userId, promise);
+  return promise;
 }
 
-export function primeSlackUserName(userId: string, name: string) {
+export function primeSlackUser(
+  userId: string,
+  partial: Partial<Omit<SlackUser, 'id'>> & { name: string }
+) {
   if (!userId) {
     return;
   }
-  cache.set(userId, name);
+  cache.set(userId, {
+    id: userId,
+    displayName: null,
+    realName: null,
+    title: null,
+    isBot: false,
+    tz: null,
+    ...partial,
+  });
 }
 
 export function normalizeSlackUserId(raw: string): string {

--- a/apps/bot/src/utils/users.ts
+++ b/apps/bot/src/utils/users.ts
@@ -2,20 +2,20 @@ import { toLogError } from '@repo/utils/error';
 import type { WebClient } from '@slack/web-api';
 import logger from '@/lib/logger';
 
-export type SlackUser = {
-  id: string;
-  name: string;
+export interface SlackUser {
   displayName: string | null;
+  id: string;
+  isBot: boolean;
+  name: string;
   realName: string | null;
   title: string | null;
-  isBot: boolean;
   tz: string | null;
-};
+}
 
 const cache = new Map<string, SlackUser>();
 const inFlight = new Map<string, Promise<SlackUser>>();
 
-export async function getSlackUser(
+export function getSlackUser(
   client: WebClient,
   userId: string
 ): Promise<SlackUser> {
@@ -30,12 +30,12 @@ export async function getSlackUser(
   };
 
   if (!userId) {
-    return fallback;
+    return Promise.resolve(fallback);
   }
 
   const cached = cache.get(userId);
   if (cached) {
-    return cached;
+    return Promise.resolve(cached);
   }
 
   const existing = inFlight.get(userId);


### PR DESCRIPTION
## Summary

Removes the bulk pre-fetch `buildUserCache` in favor of on-demand `getSlackUserName` calls. Fixes Slack rate limit bursts in large channels.

## Changes

- **`conversations.ts`**: Removed `buildUserCache` entirely. `toModelMessage` calls `getSlackUserName` on-demand per message. Message mapping loop serialized (no `Promise.all`) to prevent burst rate limits.
- `triggers.ts`: Replaced inline `client.users.info` with `getSlackUserName` (bypassing cache).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient Slack lookups with graceful fallbacks and clearer handling when a user ID is missing.
  * Note added to investigate Slack search errors causing task failures and incorrect pinned-item detection.

* **New Features**
  * Richer user profiles (display/real names, title, timezone, bot flag) surfaced in bot interactions and tools.
  * Cache priming to populate user info proactively.

* **Refactor**
  * Streamlined per-message author resolution, sequential processing, and deduplicated user requests.

* **Chores**
  * Updated task list with follow-ups for refactor and Slack search/pinned-item investigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->