### PR TITLE
fix: restore gemini vision model to re-enable image understanding

### DIFF
--- a/packages/ai/src/providers/pi.ts
+++ b/packages/ai/src/providers/pi.ts
@@ -16,14 +16,14 @@ export const chatAttempts: PiAttempt[] = [
       },
     ]
     : []),
-  // {
-  //   customEnv: {
-  //     OPENROUTER_API_KEY: env.HACKCLUB_API_KEY,
-  //     OPENROUTER_BASE_URL: 'https://ai.hackclub.com/proxy/v1',
-  //   },
-  //   model: 'google/gemini-3-flash-preview',
-  //   provider: 'hackclub',
-  // },
+  {
+    customEnv: {
+      OPENROUTER_API_KEY: env.HACKCLUB_API_KEY,
+      OPENROUTER_BASE_URL: 'https://ai.hackclub.com/proxy/v1',
+    },
+    model: 'google/gemini-3-flash-preview',
+    provider: 'hackclub',
+  },
   // ...(env.OPENROUTER_API_KEY
   //   ? [
   //       {


### PR DESCRIPTION
## Summary

- The `thermo-cleanup` refactor commented out all `google/gemini-3-flash-preview` entries from `chatAttempts` in `pi.ts`
- This left only Kimi K2 models (`kimi-k2.7-code`, `moonshotai/kimi-k2.6`) which are code/text models with **no vision capability**
- As a result, any image sent to the bot was silently ignored — the model had no way to understand visual content
- Restores the hackclub-hosted `google/gemini-3-flash-preview` as a permanent fallback since `HACKCLUB_API_KEY` is always required

## Models in use (after fix)

| Purpose | Model | Provider |
|---|---|---|
| Main agent (primary, optional) | `kimi-k2.7-code` | opencode-go |
| Main agent (fallback, optional) | `moonshotai/kimi-k2.6` | inference |
| **Main agent (vision fallback, always present)** | **`google/gemini-3-flash-preview`** | hackclub |
| `summarize-thread` tool | `google/gemini-3-flash-preview` | hackclub |
| `generate-image` tool | `google/gemini-3.1-flash-image-preview` | hackclub |

## Test plan

- [ ] Send an image to the bot and confirm it describes the image contents
- [ ] Confirm Kimi K2 still runs first when `OPENCODE_API_KEY` is set
- [ ] Confirm Gemini handles the turn when Kimi K2 keys are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)