### PR TITLE
fix: tell the agent it can view images via the read tool

### DIFF
--- a/apps/bot/src/lib/ai/attachments.ts
+++ b/apps/bot/src/lib/ai/attachments.ts
@@ -75,5 +75,6 @@ export function promptWithAttachments({
     'Attached files have already been downloaded into the sandbox workspace:',
     ...lines,
     'Use these local paths when reading, editing, or uploading the files.',
+    'For image attachments, read the file with your `read` tool to view it directly before responding.',
   ].join('\n');
 }

--- a/packages/ai/src/prompts/sandbox.ts
+++ b/packages/ai/src/prompts/sandbox.ts
@@ -7,5 +7,7 @@ You also have the ability to SSH into servers, feel free to use this ability!
 
 Files, installed packages, downloaded attachments, generated artifacts, and changes live in the sandbox. They are not visible to the chat unless you explicitly use a host tool to upload or post them back.
 
+You can see images. Reading an image file (jpg, png, gif, webp) with your \`read\` tool loads it directly into your vision so you can look at it and describe or analyse what's in it. When a user shares or references an image, read it before answering instead of saying you can't see images.
+
 The base image is minimal, install tools before first use (\`apt-get\`, \`pip3\`, \`npm\`). Read stderr and retry intelligently on failure; never loop the same failing command.
 </sandbox>`;


### PR DESCRIPTION
## Symptom

When asked about an image, the bot replies that it can't see images — even though the model is multimodal.

## Root cause (not the models)

Vision works end-to-end at the harness/model layer:

- Pi's built-in `read` tool loads image files (jpg/png/gif/webp) into the model's vision, gated only on the model declaring image input.
- Both configured models are declared image-capable in Pi's catalog (`@earendil-works/pi-ai` → `models.generated.js`):
  - `kimi-k2.7-code` → `input: ["text", "image"]`
  - `moonshotai/kimi-k2.6` → `input: ["text", "image"]`

The problem is the **system prompt**. `packages/ai/src/files/system.ts` *fully replaces* Pi's base system prompt (intentionally — HackClub rejects Pi's default). Pi's base prompt is what normally tells the agent it can view images by reading them. The replacement prompt never said this, and `core.ts` framed images only as files to process with `yt-dlp`/`ffmpeg` while `sandbox.ts` framed `read` as a text-file tool. So the agent never read the attached image into vision and reflexively declined.

## Fix

Additive prompt changes only:

- `prompts/sandbox.ts`: state that reading an image file loads it into the agent's vision, and that it should read shared images before answering.
- `lib/ai/attachments.ts`: the per-attachment hint now tells the agent to `read` image attachments to view them.

No model or provider changes — the commented-out HackClub/Gemini entries are left as-is.

## Test plan

- [ ] Share an image in a thread and ask "what's in this image?" — confirm the agent reads the file and describes it
- [ ] Confirm non-image attachments are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)