### PR TITLE
fix: make Pi's read tool return image content so the agent can see images

### DIFF
--- a/apps/bot/src/lib/ai/attachments.ts
+++ b/apps/bot/src/lib/ai/attachments.ts
@@ -75,5 +75,6 @@ export function promptWithAttachments({
     'Attached files have already been downloaded into the sandbox workspace:',
     ...lines,
     'Use these local paths when reading, editing, or uploading the files.',
+    'For image attachments, read the file with your `read` tool to view it directly before responding.',
   ].join('\n');
 }

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,9 @@
       "name": "@repo/tsconfig",
     },
   },
+  "patchedDependencies": {
+    "@ai-sdk/harness-pi@1.0.0-beta.11": "patches/@ai-sdk%2Fharness-pi@1.0.0-beta.11.patch",
+  },
   "catalog": {
     "@ai-sdk/harness": "1.0.0-beta.15",
     "@ai-sdk/harness-pi": "1.0.0-beta.11",

--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "typescript": "^6.0.3",
     "ultracite": "7.7.0"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.3.14",
+  "patchedDependencies": {
+    "@ai-sdk/harness-pi@1.0.0-beta.11": "patches/@ai-sdk%2Fharness-pi@1.0.0-beta.11.patch"
+  }
 }

--- a/packages/ai/src/prompts/sandbox.ts
+++ b/packages/ai/src/prompts/sandbox.ts
@@ -7,5 +7,7 @@ You also have the ability to SSH into servers, feel free to use this ability!
 
 Files, installed packages, downloaded attachments, generated artifacts, and changes live in the sandbox. They are not visible to the chat unless you explicitly use a host tool to upload or post them back.
 
+You can see images. Reading an image file (jpg, png, gif, webp) with your \`read\` tool loads it directly into your vision so you can look at it and describe or analyse what's in it. When a user shares or references an image, read it before answering instead of saying you can't see images.
+
 The base image is minimal, install tools before first use (\`apt-get\`, \`pip3\`, \`npm\`). Read stderr and retry intelligently on failure; never loop the same failing command.
 </sandbox>`;

--- a/patches/@ai-sdk%2Fharness-pi@1.0.0-beta.11.patch
+++ b/patches/@ai-sdk%2Fharness-pi@1.0.0-beta.11.patch
@@ -1,0 +1,27 @@
+diff --git a/dist/index.js b/dist/index.js
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1890,7 +1890,22 @@
+           });
+           if (denied) return denied;
+           const buf = await input.remoteOps.readBuffer(params.file_path);
+-          return asPiToolResult(buf.toString("utf8"));
++          const __piImageMime = (() => {
++            const b = buf;
++            if (b.length >= 8 && b[0] === 137 && b[1] === 80 && b[2] === 78 && b[3] === 71) return "image/png";
++            if (b.length >= 3 && b[0] === 255 && b[1] === 216 && b[2] === 255) return "image/jpeg";
++            if (b.length >= 6 && b[0] === 71 && b[1] === 73 && b[2] === 70) return "image/gif";
++            if (b.length >= 12 && b[0] === 82 && b[1] === 73 && b[2] === 70 && b[3] === 70 && b[8] === 87 && b[9] === 69 && b[10] === 66 && b[11] === 80) return "image/webp";
++            return void 0;
++          })();
++          if (__piImageMime) {
++            const __piImageData = buf.toString("base64");
++            if (__piImageData.length > 4.5 * 1024 * 1024) {
++              return asPiToolResult(`Read image file [${__piImageMime}]\n[Image omitted: exceeds the inline image size limit. Resize it below ~4MB before reading.]`);
++            }
++            return { content: [{ type: "text", text: `Read image file [${__piImageMime}]` }, { type: "image", data: __piImageData, mimeType: __piImageMime }], details: void 0 };
++          }
++          return asPiToolResult(buf.toString("utf8"));
+         }
+       });
+     case "write":


### PR DESCRIPTION
## Symptom

Asking the bot about an image either makes it say it can't see images, or (after telling it to read the file) it dumps raw binary and dies with "Oops, something went wrong."

## Root cause

`@ai-sdk/harness-pi`'s sandbox-backed `read` tool returns every file as text, with **no image branch**:

```js
// node_modules/@ai-sdk/harness-pi/dist/index.js  (case "read")
const buf = await input.remoteOps.readBuffer(params.file_path);
return asPiToolResult(buf.toString("utf8"));   // always UTF-8 — even for a PNG
```

This is identical in every current version (verified beta.11 → beta.17), and it **replaces** stock pi-coding-agent's read tool, which *does* return `{ type: "image", ... }` content. Consequences:

- The image never reaches the model as vision — so it can't see it (independent of model; `kimi-k2.6`/`kimi-k2.7-code` are both declared `input: ["text","image"]` in Pi's catalog).
- Reading the image injects the whole binary as text → context blows up → auto-compaction → the follow-up model call fails → generic `agentErrorMessage` prints "Oops, something went wrong."

No prompt or model change can fix this — the harness tool simply can't emit image content.

## Fix

Patch `@ai-sdk/harness-pi` (via bun `patchedDependencies`) so its `read` tool sniffs image magic bytes (png/jpeg/gif/webp) and returns proper image content parts — the same result shape pi-coding-agent's `defineTool` contract and upstream `read.ts` already use. Images over ~4.5MB base64 degrade to a text note instead of crashing the turn (no Photon/resize dependency pulled in).

Also re-adds the prompt guidance (sandbox prompt + attachment hint) telling the agent it can view images by reading them — now that reading one actually loads it into vision.

### Files
- `patches/@ai-sdk%2Fharness-pi@1.0.0-beta.11.patch` — the read-tool image patch
- `package.json` — `patchedDependencies` entry
- `packages/ai/src/prompts/sandbox.ts`, `apps/bot/src/lib/ai/attachments.ts` — prompt guidance

## Verification

- `git apply --check` passes against the pinned beta.11 dist
- patched `dist/index.js` passes `node --check`
- magic-byte sniff unit-tested against png/jpeg/gif/webp/text
- ⚠️ I could not run `bun install` in my environment — please run it to apply the patch, then test by sharing an image and asking what's in it.

## Note on models
Main agent runs `kimi-k2.7-code` (opencode-go) → `moonshotai/kimi-k2.6` (OpenRouter); both are vision-capable. The hackclub Gemini entries in `pi.ts` remain commented out and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)